### PR TITLE
Add refreshToken action

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ axios.interceptors.request.use(async config => {
 
 `$store.dispatch('signOut')`
 
+**Refresh token**
+
+`$store.dispatch('refreshToken')`
+
 ## Twitter
 
 [Follow me on Twitter](https://twitter.com/KrolsBjorn)

--- a/src/actions.js
+++ b/src/actions.js
@@ -252,5 +252,34 @@ export default {
       user.signOut();
       commit('setAuthenticated', null);
     }
+  },
+  /* Refresh token */
+  refreshToken({ commit, state }) {
+    return new Promise((resolve, reject) => {
+      const user = state.pool.getCurrentUser();
+      if (user != null) {
+        user.getSession(function(error, session) {
+          if (error) {
+            reject(error);
+          } else {
+            const refreshToken = session.getRefreshToken();
+            user.refreshSession(refreshToken, (err, session) => {
+              if (err) {
+                reject(err);
+              } else {
+                try {
+                  commit('setAuthenticated', user);
+                  resolve(session);
+                } catch (e) {
+                  reject(e);
+                }
+              }
+            });
+          }
+        });
+      } else {
+        resolve();
+      }
+    });
   }
 };


### PR DESCRIPTION
There's a good chance I'm misunderstanding how to handle token expiration, but I needed a way to refresh the token. My usage looks something like this:

```javascript
  const session = await store.dispatch('getUserSession');
  if (session) {
    const token = decode(session.idToken.jwtToken);
    if (token.exp < Math.round(Date.now() / 1000)) {
      await store.dispatch('refreshToken');
    }
  }
```

Is this useful, or did I miss something?